### PR TITLE
Fix/device action2

### DIFF
--- a/src/library/thingsboardConnecter/mqtt/deviceEntity.ts
+++ b/src/library/thingsboardConnecter/mqtt/deviceEntity.ts
@@ -155,6 +155,7 @@ export default class TBDeviceEntity {
           this.timer = undefined;
           this.deleteSendDataAction();
           clearInterval(id);
+          simpleMsg(`The ${this.device.name}'s mockDataEntity not exist. Clear send data interval`);
         } else {
           const rawData = jsonStringify(mock.generate());
           client.publish('v1/devices/me/telemetry', rawData, () => {

--- a/src/library/thingsboardConnecter/mqtt/deviceEntity.ts
+++ b/src/library/thingsboardConnecter/mqtt/deviceEntity.ts
@@ -94,6 +94,7 @@ export default class TBDeviceEntity {
       return true;
     }
     this.canMapMockDataEntity = false;
+    this.mockDataEntity = undefined;
     return false;
   }
 
@@ -149,13 +150,20 @@ export default class TBDeviceEntity {
     if (mock) {
       this.sendTimes = 0;
       const id = delayInterval(this.sendDataDelay, () => {
-        const rawData = jsonStringify(mock.generate());
-        client.publish('v1/devices/me/telemetry', rawData, () => {
-          simpleMsg(`${this.device.name} send data`);
-          this.historySendTimes += 1;
-          this.sendTimes += 1;
-          this.endTime = new Date().getTime();
-        });
+        this.updateSendDataFlag();
+        if (!this.canMapMockDataEntity) {
+          this.timer = undefined;
+          this.deleteSendDataAction();
+          clearInterval(id);
+        } else {
+          const rawData = jsonStringify(mock.generate());
+          client.publish('v1/devices/me/telemetry', rawData, () => {
+            simpleMsg(`${this.device.name} send data`);
+            this.historySendTimes += 1;
+            this.sendTimes += 1;
+            this.endTime = new Date().getTime();
+          });
+        }
       });
       this.timer = id;
       this.startTime = new Date().getTime();

--- a/src/service/device/setDeviceAction.ts
+++ b/src/service/device/setDeviceAction.ts
@@ -51,7 +51,7 @@ export function getAllDeviceAction() {
     // 因為send data是每次interval才會執行
     // 因此要確保Get action config list狀態是即時的
     entity.updateSendDataFlag();
-    if (entity.getCanMapMockDataEntity()) {
+    if (entity.getCanMapMockDataEntity() === false) {
       entity.deleteSendDataAction();
     }
     const infos = entity.getInfos();

--- a/src/service/device/setDeviceAction.ts
+++ b/src/service/device/setDeviceAction.ts
@@ -47,9 +47,15 @@ export async function setDevicesAction(tenantToken: string, deviceList: Devices)
 
 export function getAllDeviceAction() {
   const array: any[] = [];
-  map.forEach((value) => {
-    const v = value.getInfos();
-    array.push(v);
+  map.forEach((entity) => {
+    // 因為send data是每次interval才會執行
+    // 因此要確保Get action config list狀態是即時的
+    entity.updateSendDataFlag();
+    if (entity.getCanMapMockDataEntity()) {
+      entity.deleteSendDataAction();
+    }
+    const infos = entity.getInfos();
+    array.push(infos);
   });
 
   const DTO = new GetAllDeviceActionDTO(array);

--- a/src/service/device/setDeviceAction.ts
+++ b/src/service/device/setDeviceAction.ts
@@ -47,6 +47,7 @@ export async function setDevicesAction(tenantToken: string, deviceList: Devices)
 
 export function getAllDeviceAction() {
   const array: any[] = [];
+  loggers.debug('update device entity status', 'Get all devices action');
   map.forEach((entity) => {
     // 因為send data是每次interval才會執行
     // 因此要確保Get action config list狀態是即時的


### PR DESCRIPTION
# PR describes

User deletes mock data entity during devices send data.
The device action list status will error.

This PR will add the check device mock data entity function into the GET device action list API.
So the device action list will be in real-time.

At the same time, add a simple message to say the device mock data entity does not exist.